### PR TITLE
refactor: rename struct

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  
+
 permissions:
   contents: write
 
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Test with Go
         run: go test -v ./...
@@ -29,8 +29,8 @@ jobs:
           pwd
           ls -la
           mkdir -p build || exit 1
-          go build -v -o build/feeti-module . || exit 1
-          
+          go build -ldflags="-s -w" -v -o build/feeti-module . || exit 1
+
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/emmadal/feeti-module
 
 go 1.21.0
 
-toolchain go1.23.4
+toolchain go1.21
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/models/user.go
+++ b/models/user.go
@@ -35,22 +35,22 @@ type Wallet struct {
 	UpdatedAt time.Time       `json:"updated_at"`
 }
 
-// UserLogin is the struct for login
-type UserLogin struct {
+// Login is the struct for login
+type Login struct {
 	PhoneNumber string `json:"phone_number" binding:"required,e164,min=11,max=14"`
 	Pin         string `json:"pin" binding:"required,len=4,numeric,min=4,max=4"`
 }
 
-// UserResetPin is the struct for resetting the pin
-type UserResetPin struct {
+// ResetPin is the struct for resetting the pin
+type ResetPin struct {
 	PhoneNumber string `json:"phone_number" binding:"required,e164,min=11,max=14"`
 	Pin         string `json:"pin" binding:"required,len=4,numeric,min=4,max=4"`
 	CodeOTP     string `json:"code_otp" binding:"required,len=6,numeric,min=6,max=6"`
 	KeyUID      string `json:"key_uid" binding:"required,uuid"`
 }
 
-// UserUpdatePin is the struct for updating the pin
-type UserUpdatePin struct {
+// UpdatePin is the struct for updating the pin
+type UpdatePin struct {
 	PhoneNumber string `json:"phone_number" binding:"required,e164,min=11,max=14"`
 	OldPin      string `json:"old_pin" binding:"required,len=4,numeric,min=4,max=4"`
 	NewPin      string `json:"new_pin" binding:"required,len=4,numeric,min=4,max=4"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified struct names in models/user.go by removing redundant "User" prefix while maintaining all functionality:
  - `UserLogin` -> `Login`
  - `UserResetPin` -> `ResetPin` 
  - `UserUpdatePin` -> `UpdatePin`
- Downgraded Go toolchain version from 1.23.4 to 1.21 in go.mod



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.go</strong><dd><code>Simplified struct names by removing redundant User prefix</code></dd></summary>
<hr>

models/user.go

<li>Renamed <code>UserLogin</code> struct to <code>Login</code><br> <li> Renamed <code>UserResetPin</code> struct to <code>ResetPin</code><br> <li> Renamed <code>UserUpdatePin</code> struct to <code>UpdatePin</code><br> <li> Kept all struct fields and validation rules unchanged<br>


</details>


  </td>
  <td><a href="https://github.com/emmadal/feeti-module/pull/7/files#diff-f9c27c5d201f4eb9a23b855d52131aab43a1842aeedcf9356797c4ae75c224df">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Downgrade Go toolchain version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Updated Go toolchain version from 1.23.4 to 1.21



</details>


  </td>
  <td><a href="https://github.com/emmadal/feeti-module/pull/7/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information