### PR TITLE
fix: remove unused field

### DIFF
--- a/models/otp.go
+++ b/models/otp.go
@@ -11,7 +11,7 @@ type Otp struct {
 	IsUsed      bool      `json:"is_used" gorm:"type:boolean;not null;default:false"`
 	PhoneNumber string    `json:"phone_number" gorm:"type:varchar(15);not null;index" binding:"required,e164,min=11,max=14"`
 	KeyUID      string    `json:"key_uid" gorm:"type:varchar(100);not null;index" binding:"required,uuid"`
-	ExpiryAt    time.Time `json:"expiry_at" binding:"required,gtfield=CreatedAt,future"`
+	ExpiryAt    time.Time `json:"expiry_at" binding:"required,gtfield=CreatedAt"`
 	CreatedAt   time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed validation constraint in `Otp` struct by removing the `future` tag from `ExpiryAt` field
- The field still maintains the `required` and `gtfield=CreatedAt` validations
- This change allows more flexible handling of OTP expiration times



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>otp.go</strong><dd><code>Remove future validation constraint from OTP expiry field</code></dd></summary>
<hr>

models/otp.go

<li>Removed <code>future</code> validation tag from <code>ExpiryAt</code> field in <code>Otp</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/emmadal/feeti-module/pull/8/files#diff-8644df2eae34b3025e3e66b4ce65663c9e7c5bdddb93053a6d92d8a946eaa46d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information